### PR TITLE
Skip fields without designation

### DIFF
--- a/python/git-credential-1password
+++ b/python/git-credential-1password
@@ -188,6 +188,8 @@ def parseOpItem(item):
 
   
   for record in fields:
+    if "designation" not in record:
+      continue
     if record["designation"] == 'username':
       username = record["value"]
     if record["designation"] == 'password':


### PR DESCRIPTION
I have entries in 1Password containing fields that lack a designation.   This change prevents the script from dying when it attempts to access the nonexistent key.